### PR TITLE
Sync readme contributors to real one

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ For more information about each POC, please refer to the main README file locate
 
 # Contributors
 
-| <img src="https://avatars.githubusercontent.com/u/91665380" alt="drawing" width="200"/> | 
-|:-:|
-| [Quentin Brejoin](https://www.github.com/Queng123) | 
+![alt](https://contrib.rocks/image?repo=Queng123/agent-pocs)
 
 # License
 


### PR DESCRIPTION
Currently, if you have some new contributors, you have to add them manually which can be a little boring. This update allows to sync contributors directly with real ones.